### PR TITLE
Installed prettier separately for server + client

### DIFF
--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true,
+  "semi": true
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12169,6 +12169,12 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -30,5 +30,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "^2.1.2"
   }
 }

--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true,
+  "semi": true
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3123,6 +3123,11 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "mongoose": "^5.10.13",
     "morgan": "~1.9.1",
     "nodemon": "^1.19.1",
+    "prettier": "^2.1.2",
     "validator": "^13.1.17"
   },
   "devDependencies": {


### PR DESCRIPTION
Installed prettier dependency on both the server and client.

Run npm install in the root of both directories to have prettier installed. If you have VSCode install the Prettier extension as well. You can have VSCode auto-format code on save by enabling this in settings. Alternatively you can also press alt + shift + f (on Windows) on your keyboard and VSCode will format it for you.